### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-mjegkllh/overlays/prod/deployment-patch.yaml
+++ b/components/go-mjegkllh/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/rhtap-task-runner:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-mjegkllh:github-716048caf2a799ff5a29a4a7f35218886028a5d2
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-mjegkllh:github-716048caf2a799ff5a29a4a7f35218886028a5d2